### PR TITLE
Add badge for tests to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Resolvent4py
 
+[![Tests](https://github.com/albertopadovan/resolvent4py/actions/workflows/tests.yml/badge.svg)](https://github.com/albertopadovan/resolvent4py/actions/workflows/tests.yml)
+
 Resolvent4py is a petsc4py-based package for the analysis, model reduction
 and control of large-scale linear systems. 
 


### PR DESCRIPTION
Resolves #21.  I decided not to add a badge for coverage, because this is not supported directly by GitHub, and requires an external tool (such as coveralls).  It can certainly be done if we want, but doesn't seem worth it to me.